### PR TITLE
chore(renovate): adopt native mise manager + track tests/*.sh image pins

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,33 +1,22 @@
 [tools]
-# renovate: datasource=golang-version depName=go
+# Versions tracked by the native Renovate `mise` manager (no `# renovate:`
+# annotations needed — mise extracts every entry via its built-in
+# datasources: golang-version for go, node-version for node, github-tags
+# for aqua: backends, the Go module proxy for go: backends, etc.).
 go = "1.26.2"
-# renovate: datasource=github-releases depName=nodejs/node extractVersion=^v(?<version>\d+)
 node = "24"
-# renovate: datasource=github-releases depName=protocolbuffers/protobuf extractVersion=^v(?<version>.*)$
 protoc = "34.1"
-# renovate: datasource=github-releases depName=protocolbuffers/protobuf-go extractVersion=^v(?<version>.*)$
 protoc-gen-go = "1.36.11"
-# renovate: datasource=github-releases depName=grpc/grpc-go extractVersion=^cmd/protoc-gen-go-grpc/v(?<version>.*)$
 protoc-gen-go-grpc = "1.6.1"
 
 # === Lint / security / CI tooling (migrated from Makefile per portfolio mise policy) ===
-# renovate: datasource=github-releases depName=golangci/golangci-lint
 golangci-lint = "2.11.4"
-# renovate: datasource=github-releases depName=zricethezav/gitleaks
 gitleaks = "8.30.1"
-# renovate: datasource=github-releases depName=rhysd/actionlint
 actionlint = "1.7.12"
-# renovate: datasource=github-releases depName=koalaman/shellcheck
 shellcheck = "0.11.0"
-# renovate: datasource=github-releases depName=aquasecurity/trivy
 trivy = "0.69.3"
-# renovate: datasource=github-releases depName=nektos/act
 act = "0.2.87"
-# renovate: datasource=github-releases depName=hadolint/hadolint
 hadolint = "2.14.0"
-# renovate: datasource=github-releases depName=kubernetes-sigs/kind
 kind = "0.31.0"
-# renovate: datasource=github-releases depName=securego/gosec
 "aqua:securego/gosec" = "2.25.0"
-# renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
 "go:golang.org/x/vuln/cmd/govulncheck" = "1.1.4"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Reference implementation of a Go microservice platform on [Dapr](https://dapr.io
 | Test layers | Unit (Go testing), Integration (Testcontainers), E2E (KinD + curl) | Each layer catches a different class of defect |
 | Tool versioning | [mise](https://mise.jdx.dev) | Single source of truth for every CLI: Go, kind, golangci-lint, gosec, hadolint, trivy, gitleaks, actionlint, shellcheck, act, protoc, protoc-gen-* — pinned in `.mise.toml`, installed by `make deps` |
 | Code quality | golangci-lint, gosec, hadolint, mermaid-cli | Enforced via composite `make static-check` gate |
-| Dependency updates | [Renovate](https://docs.renovatebot.com/) | Built-in `gomod` / `github-actions` / `dockerfile` / `kubernetes` managers + custom-regex coverage of Makefile, `.mise.toml`, and workflow `with:` pins |
+| Dependency updates | [Renovate](https://docs.renovatebot.com/) | Built-in `gomod` / `github-actions` / `dockerfile` / `kubernetes` / `mise` managers + custom-regex coverage of Makefile constants, workflow `with:` pins, and `tests/*.sh` image pins |
 
 ## Building Blocks Demonstrated
 
@@ -501,7 +501,7 @@ The `changes` job uses the canonical path-filter expression so doc-only changes 
 
 No custom secrets required — CI uses only the implicit `GITHUB_TOKEN`.
 
-[Renovate](https://docs.renovatebot.com/) auto-merges minor/patch updates after CI passes (3-day minimum release age on majors). Coverage spans the built-in `gomod` / `github-actions` / `dockerfile` / `kubernetes` managers plus three custom-regex managers for Makefile constants, `.mise.toml` tool pins, and workflow `with:` value pins.
+[Renovate](https://docs.renovatebot.com/) auto-merges minor/patch updates after CI passes (3-day minimum release age on majors). Coverage spans the built-in `gomod` / `github-actions` / `dockerfile` / `kubernetes` / `mise` managers plus three custom-regex managers for Makefile constants, workflow `with:` value pins, and `tests/*.sh` shell-script image pins. Dapr SDK and Go-toolchain bumps are grouped into single PRs to avoid concurrent-update collisions.
 
 A scheduled workflow (`.github/workflows/cleanup-runs.yml`) removes workflow runs older than 7 days weekly (retains last 5 regardless of age).
 

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:best-practices",
     ":semanticCommitType(chore)"
   ],
-  "enabledManagers": ["gomod", "github-actions", "dockerfile", "kubernetes", "custom.regex"],
+  "enabledManagers": ["gomod", "github-actions", "dockerfile", "kubernetes", "mise", "custom.regex"],
   "kubernetes": {
     "managerFilePatterns": ["/^k8s/.+\\.ya?ml$/"]
   },
@@ -43,18 +43,18 @@
     },
     {
       "customType": "regex",
-      "description": "Update .mise.toml tool pins via inline renovate comments",
-      "managerFilePatterns": ["/^\\.mise\\.toml$/"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ]
-    },
-    {
-      "customType": "regex",
       "description": "Update GitHub Actions workflow `with:` value pins via inline renovate comments (e.g., dapr/setup-dapr@v2 with: version)",
       "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+))?\\n\\s*[a-zA-Z_]+:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update shell script tool versions via inline renovate comments (e.g., tests/e2e.sh CURL_IMAGE_VERSION)",
+      "managerFilePatterns": ["/^(scripts|tests)/.+\\.sh$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+\\s*=\\s*[\"'](?<currentValue>[^\"']+)[\"']"
       ]
     }
   ],

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -17,6 +17,12 @@ NAMESPACE_INVENTORY="dapr-go-hero-inventory"
 NAMESPACE_PRODUCTS="dapr-go-hero-products"
 NAMESPACE_INFRA="dapr-go-hero"
 
+# Image used by the access-control probe pod (check_access_control_enforcement).
+# Pinned + Renovate-tracked so it doesn't silently go stale; a renovate.json
+# custom.regex over tests/*.sh picks up this annotation.
+# renovate: datasource=docker depName=curlimages/curl
+CURL_IMAGE_VERSION="8.10.1"
+
 # Pin kubectl to the kind-<cluster> context so a parallel `make` run from a
 # sibling KinD-using project that calls `kubectl config use-context` cannot
 # silently flip our context mid-script. KIND_CLUSTER_NAME is exported by the
@@ -447,7 +453,7 @@ spec:
   serviceAccountName: inventory
   containers:
     - name: curl
-      image: curlimages/curl:8.10.1
+      image: curlimages/curl:${CURL_IMAGE_VERSION}
       command: ["sleep", "180"]
 EOF
 


### PR DESCRIPTION
## Summary

Two findings from `/renovate` (Go + Docker + mise + K8s + GH Actions project):

1. **`tests/e2e.sh:450` had literal `image: curlimages/curl:8.10.1`** in the access-control probe pod heredoc — untracked by Renovate (skill rule #27: no `# renovate:` comment, no variable). Extracted to a `CURL_IMAGE_VERSION` shell variable with `# renovate: datasource=docker depName=curlimages/curl` annotation. Added a new \`custom.regex\` manager scoped to \`^(scripts|tests)/.+\\.sh\$\` so future shell-script image pins are tracked the same way.

2. **`.mise.toml` was tracked via `custom.regex` instead of the native `mise` manager.** Switched: added \`"mise"\` to \`enabledManagers\`, dropped the \`.mise.toml\` custom.regex entry. mise extracts every entry natively (golang-version for go, node-version for node, github-tags for aqua: backends, Go module proxy for go: backends). Cleaned up the now-dead `# renovate:` comments inside \`.mise.toml\` to plain doc comments to avoid misleading future readers.

## Validation

\`make renovate-validate\` output:

| | Before | After |
|---|---|---|
| dockerfile | 6 deps | 6 |
| github-actions | 33 | 33 |
| gomod | 84 | 84 |
| kubernetes | 12 | 12 |
| **mise** | **(absent)** | **15** |
| regex | 21 | **9** |
| **Total** | 156 | **159** |

- 0 \`validationError\` lines
- mise picks up all 15 \`.mise.toml\` entries natively
- regex shrinks (no .mise.toml duplicate); now covers Makefile + workflow `with:` + new tests/*.sh
- 1 expected GH-token INFO (running locally)

README + CLAUDE.md updated to reflect the new manager set; mermaid-lint green.

## Test plan

- [x] \`make renovate-validate\` clean
- [x] \`make mermaid-lint\` clean
- [x] \`make static-check\` clean
- [ ] CI \`ci-pass\` green on this PR (this is the gate; the new branch protection ruleset that bit me on the direct-push attempt enforces it)