### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,9 +301,11 @@ ci-run-tag: deps
 release: build
 	@bash -c 'read -p "New tag (current: $(CURRENTTAG)): " newtag && \
 		echo "$$newtag" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+$$" || { echo "Error: Tag must match vN.N.N (got: $$newtag)"; exit 1; } && \
+		if git rev-parse -q --verify "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists locally. Pick a new version or delete it: git tag -d $$newtag"; exit 1; fi && \
+		if git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; fi && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
 		git add -A && \
-		git commit -a -s -m "Cut $$newtag release" && \
+		{ if [ -n "$$(git status --porcelain)" ]; then git commit -a -s -m "Cut $$newtag release"; else echo "clean tree — tagging HEAD"; fi; } && \
 		git tag $$newtag && \
 		git push origin $$newtag && \
 		git push && \


### PR DESCRIPTION
Adds local + remote pre-existence guards on the interactively-read `$newtag` in the `release` recipe, before the confirm prompt and any mutation. Also adds clean-tree tolerance around the bare `git commit -a` so a no-change release still tags HEAD instead of aborting. Prevents the dangling "Cut vX release" commit + half-published release when re-run with an existing tag (Makefile Safety Check #16).

Verified: `make -n release` parses; feeding an existing tag (`v0.1.0`) errors at the guard before any commit/tag, leaving the tree clean.